### PR TITLE
feat: Implement serialize all namespaces in root feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14154,7 +14154,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@xinvoice/xmldom-decorators": "1.2.0",
+        "@xinvoice/xmldom-decorators": "file:../xmldom-decorators",
         "commander": "^11.1.0"
       },
       "bin": {
@@ -14173,39 +14173,25 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "@xinvoice/xmldom-decorators": "1.1.0",
-        "@xinvoice/xmldom-decorators-cli": "1.1.0"
+        "@xinvoice/xmldom-decorators": "file:../xmldom-decorators",
+        "@xinvoice/xmldom-decorators-cli": "file:../xmldom-decorators-cli"
       },
       "devDependencies": {
         "@types/node": "^20.11.10",
         "alsatian": "3.2.1",
+        "jest": "^29.7.0",
         "typescript": "^5.3.3"
       }
     },
     "packages/xmldom-decorators-test/node_modules/@xinvoice/xmldom-decorators": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@xinvoice/xmldom-decorators/-/xmldom-decorators-1.1.0.tgz",
-      "integrity": "sha512-iqy5hDdk0MY0JtloEYVbpYIguPR27YE5xfK2kre21hu6aMBs9ge9Lo2Yu26YvflPkFwPyw+9NbfbyNeDW1MOJQ==",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.10",
-        "reflect-metadata": "^0.1.12"
-      }
+      "resolved": "xmldom-decorators",
+      "link": true
     },
     "packages/xmldom-decorators-test/node_modules/@xinvoice/xmldom-decorators-cli": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@xinvoice/xmldom-decorators-cli/-/xmldom-decorators-cli-1.1.0.tgz",
-      "integrity": "sha512-15//48FVxyC0Acxv/ANzro/PXjcwDv5/PQiyffL1rLYjGmfSc5i+FVpvFqTIMjemta8nkht6cQRYCTSzK6kTFw==",
-      "dependencies": {
-        "@xinvoice/xmldom-decorators": "1.1.0"
-      },
-      "bin": {
-        "xmldom-decorators-cli": "lib/index.js"
-      }
+      "resolved": "xmldom-decorators-cli",
+      "link": true
     },
-    "packages/xmldom-decorators-test/node_modules/reflect-metadata": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
-    }
+    "xmldom-decorators": {},
+    "xmldom-decorators-cli": {}
   }
 }

--- a/packages/xmldom-decorators-cli/package.json
+++ b/packages/xmldom-decorators-cli/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@xinvoice/xmldom-decorators": "1.2.0",
+    "@xinvoice/xmldom-decorators": "file:../xmldom-decorators",
     "commander": "^11.1.0"
   },
   "jest": {

--- a/packages/xmldom-decorators-test/data/cii/cii-minimal.xsd
+++ b/packages/xmldom-decorators-test/data/cii/cii-minimal.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+           xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+           xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+           targetNamespace="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+           elementFormDefault="qualified">
+   
+    <xs:import namespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" schemaLocation="cii-ram-minimal.xsd"/>
+    <xs:element name="CrossIndustryInvoice" type="rsm:CrossIndustryInvoiceType"/>
+    <xs:complexType name="CrossIndustryInvoiceType">
+        <xs:sequence>
+            <xs:element name="ExchangedDocumentContext" type="ram:ExchangedDocumentContextType"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/packages/xmldom-decorators-test/data/cii/cii-ram-minimal.xsd
+++ b/packages/xmldom-decorators-test/data/cii/cii-ram-minimal.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+           targetNamespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+           elementFormDefault="qualified">
+    <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="cii-udt-minimal.xsd"/>
+    <xs:complexType name="DocumentContextParameterType">
+        <xs:sequence>
+            <xs:element name="ID" type="udt:IDType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ExchangedDocumentContextType">
+        <xs:sequence>
+            <xs:element name="GuidelineSpecifiedDocumentContextParameter" type="ram:DocumentContextParameterType"/>
+            <xs:element name="GuidelineSpecifiedDocumentContextParameter2" type="ram:DocumentContextParameterType"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/packages/xmldom-decorators-test/data/cii/cii-udt-minimal.xsd
+++ b/packages/xmldom-decorators-test/data/cii/cii-udt-minimal.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+           elementFormDefault="qualified"
+           version="100.D16B">
+    <xs:complexType name="IDType">
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute name="schemeID" type="xs:token" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/packages/xmldom-decorators-test/package.json
+++ b/packages/xmldom-decorators-test/package.json
@@ -16,15 +16,30 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "alsatian lib/*.test.js"
+    "test": "alsatian lib/*.test.js && npm run test:jest",
+    "test:jest": "jest --testPathPattern=src/jest",
+    "xsd-cii": "EXPERIMENT=true xmldom-decorators-cli xsd ./data/cii/cii-minimal.xsd -o ./src/schema/cii"
   },
   "devDependencies": {
     "@types/node": "^20.11.10",
-    "typescript": "^5.3.3",
-    "alsatian": "3.2.1"
+    "alsatian": "3.2.1",
+    "jest": "^29.7.0",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@xinvoice/xmldom-decorators": "1.1.0",
-    "@xinvoice/xmldom-decorators-cli": "1.1.0"
+    "@xinvoice/xmldom-decorators": "file:../xmldom-decorators",
+    "@xinvoice/xmldom-decorators-cli": "file:../xmldom-decorators-cli"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(ts?)$",
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "json",
+      "node"
+    ]
   }
 }

--- a/packages/xmldom-decorators-test/src/jest/serialize-all-ns-in-root.test.ts
+++ b/packages/xmldom-decorators-test/src/jest/serialize-all-ns-in-root.test.ts
@@ -1,0 +1,64 @@
+import { XMLDecoratorSerializer } from "@xinvoice/xmldom-decorators";
+import { CrossIndustryInvoice } from "../schema/cii/CrossIndustryInvoice";
+
+describe('serialize-all-ns-in-root', () => {
+    /**
+     * Test case: We have an XSD with three imports for three different namespaces. 
+     * We want to serialize the object to XML and have all three namespaces in the root element.
+     */
+    it('should serialize all ns in root when feature is enabled', () => {
+        const data: CrossIndustryInvoice = {
+            exchangedDocumentContext: {
+                guidelineSpecifiedDocumentContextParameter: {
+                    iD: {
+                        value:
+                            'placeholder-id-for-testing',
+                    },
+                },
+                guidelineSpecifiedDocumentContextParameter2: {
+                    iD: {
+                        value:
+                            'placeholder-id-for-testing-2',
+                    },
+                },
+
+            },
+        };
+
+        const serializer = new XMLDecoratorSerializer();
+        serializer.setExperimentFlag('SERIALIZE_ALL_NAMESPACES_IN_ROOT', true);
+        const xml = serializer.serialize(
+            data,
+            CrossIndustryInvoice
+        );
+        expect(xml).toMatchInlineSnapshot(`"<p0:CrossIndustryInvoice xmlns:p1="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:p0="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"><p0:ExchangedDocumentContext><p1:GuidelineSpecifiedDocumentContextParameter><p1:ID>placeholder-id-for-testing</p1:ID></p1:GuidelineSpecifiedDocumentContextParameter><p1:GuidelineSpecifiedDocumentContextParameter2><p1:ID>placeholder-id-for-testing-2</p1:ID></p1:GuidelineSpecifiedDocumentContextParameter2></p0:ExchangedDocumentContext></p0:CrossIndustryInvoice>"`);
+    });
+
+    it("should not serialize all ns in root when feature is disabled", () => {
+        const data: CrossIndustryInvoice = {
+            exchangedDocumentContext: {
+                guidelineSpecifiedDocumentContextParameter: {
+                    iD: {
+                        value:
+                            'placeholder-id-for-testing',
+                    },
+                },
+                guidelineSpecifiedDocumentContextParameter2: {
+                    iD: {
+                        value:
+                            'placeholder-id-for-testing-2',
+                    },
+                },
+
+            },
+        };
+
+        const serializer = new XMLDecoratorSerializer();
+        serializer.setExperimentFlag('SERIALIZE_ALL_NAMESPACES_IN_ROOT', false);
+        const xml = serializer.serialize(
+            data,
+            CrossIndustryInvoice
+        );
+        expect(xml).toMatchInlineSnapshot(`"<p0:CrossIndustryInvoice xmlns:p0="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"><p0:ExchangedDocumentContext><p1:GuidelineSpecifiedDocumentContextParameter xmlns:p1="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"><p1:ID>placeholder-id-for-testing</p1:ID></p1:GuidelineSpecifiedDocumentContextParameter><p1:GuidelineSpecifiedDocumentContextParameter2 xmlns:p1="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"><p1:ID>placeholder-id-for-testing-2</p1:ID></p1:GuidelineSpecifiedDocumentContextParameter2></p0:ExchangedDocumentContext></p0:CrossIndustryInvoice>"`);
+    });
+})

--- a/packages/xmldom-decorators-test/src/schema/cii/CrossIndustryInvoice.ts
+++ b/packages/xmldom-decorators-test/src/schema/cii/CrossIndustryInvoice.ts
@@ -1,0 +1,11 @@
+import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";
+
+import { ExchangedDocumentContextType } from "./ExchangedDocumentContextType";
+
+@XMLRoot({name: "CrossIndustryInvoice", namespaceUri: "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"})
+export class CrossIndustryInvoice {
+    @XMLElement({types: [{ name: "ExchangedDocumentContext", namespaceUri: "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" }]})
+    exchangedDocumentContext: ExchangedDocumentContextType = new ExchangedDocumentContextType();
+
+}
+

--- a/packages/xmldom-decorators-test/src/schema/cii/DocumentContextParameterType.ts
+++ b/packages/xmldom-decorators-test/src/schema/cii/DocumentContextParameterType.ts
@@ -1,0 +1,11 @@
+import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";
+
+import { IDType } from "./IDType";
+
+@XMLRoot({name: "DocumentContextParameterType", namespaceUri: "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"})
+export class DocumentContextParameterType {
+    @XMLElement({types: [{ name: "ID", namespaceUri: "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" }]})
+    iD?: IDType;
+
+}
+

--- a/packages/xmldom-decorators-test/src/schema/cii/ExchangedDocumentContextType.ts
+++ b/packages/xmldom-decorators-test/src/schema/cii/ExchangedDocumentContextType.ts
@@ -1,0 +1,14 @@
+import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";
+
+import { DocumentContextParameterType } from "./DocumentContextParameterType";
+
+@XMLRoot({name: "ExchangedDocumentContextType", namespaceUri: "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"})
+export class ExchangedDocumentContextType {
+    @XMLElement({types: [{ name: "GuidelineSpecifiedDocumentContextParameter", namespaceUri: "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" }]})
+    guidelineSpecifiedDocumentContextParameter: DocumentContextParameterType = new DocumentContextParameterType();
+
+    @XMLElement({types: [{ name: "GuidelineSpecifiedDocumentContextParameter2", namespaceUri: "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" }]})
+    guidelineSpecifiedDocumentContextParameter2: DocumentContextParameterType = new DocumentContextParameterType();
+
+}
+

--- a/packages/xmldom-decorators-test/src/schema/cii/IDType.ts
+++ b/packages/xmldom-decorators-test/src/schema/cii/IDType.ts
@@ -1,0 +1,13 @@
+import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";
+
+
+@XMLRoot({name: "IDType", namespaceUri: "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"})
+export class IDType {
+    @XMLText()
+    value: string = "";
+
+    @XMLAttribute({namespaceUri: "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"})
+    schemeID?: string = undefined;
+
+}
+

--- a/packages/xmldom-decorators/tsconfig.json
+++ b/packages/xmldom-decorators/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
##  🎉 New Experimental Feature for XML Serialization: "All Namespaces in Root"
We're excited to introduce an experimental feature in XML serialization, "All Namespaces in Root". This feature optimizes XML file size by declaring global namespaces at the root level, rather than with each child element. This is particularly beneficial for large documents transmitted over limited bandwidth, as it significantly reduces file size.

**How to Enable:**
 ```ts
const serializer = new XMLDecoratorSerializer();
serializer.setExperimentFlag('SERIALIZE_ALL_NAMESPACES_IN_ROOT', true);
```

**Output Comparison:**
```xml
<p0:CrossIndustryInvoice xmlns:p0="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100">
    <p0:ExchangedDocumentContext>
        <ram:GuidelineSpecifiedDocumentContextParameter xmlns:p1="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
            <p1:ID>placeholder-id-for-testing</p1:ID>
        </p1:GuidelineSpecifiedDocumentContextParameter>
        <p1:GuidelineSpecifiedDocumentContextParameter2 xmlns:p1="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
            <p1:ID>placeholder-id-for-testing-2</p1:ID>
        </p1:GuidelineSpecifiedDocumentContextParameter2>
    </p0:ExchangedDocumentContext>
</p0:CrossIndustryInvoice>
```
*711 Chars*

with enabled feature:

```xml
<p0:CrossIndustryInvoice
    xmlns:p1="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
    xmlns:p0="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100">
    <p0:ExchangedDocumentContext>
        <p1:GuidelineSpecifiedDocumentContextParameter>
            <p1:ID>placeholder-id-for-testing</p1:ID>
        </p1:GuidelineSpecifiedDocumentContextParameter>
        <p1:GuidelineSpecifiedDocumentContextParameter2>
            <p1:ID>placeholder-id-for-testing-2</p1:ID>
        </p1:GuidelineSpecifiedDocumentContextParameter2>
    </p0:ExchangedDocumentContext>
</p0:CrossIndustryInvoice>
```
*622 Chars*


